### PR TITLE
feat: 유저 아이템(Inventory) 관련 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,20 @@ repositories {
 }
 
 dependencies {
+    // lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    // map struct
+    implementation 'org.mapstruct:mapstruct:1.5.5.Final'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
+    annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0' // Lombok + MapStruct 연동용
+
+    // 기존 queryDSL의 보안 취약성 및 사실상 없는 유지보수 때문에 openfeign의 최신 (7.1 버전) QueryDSL 이용.
+    implementation "io.github.openfeign.querydsl:querydsl-jpa:7.1"
+    annotationProcessor "io.github.openfeign.querydsl:querydsl-apt:7.1:jakarta"
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
     implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
@@ -37,25 +51,38 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     testImplementation 'io.projectreactor:reactor-test'
 
+    // jwt
     implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
 
-    implementation 'org.mapstruct:mapstruct:1.5.5.Final'
-    annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
-    annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0' // Lombok + MapStruct 연동용
-
-    compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
     runtimeOnly 'com.mysql:mysql-connector-j'
-    annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:mysql'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+// Querydsl 빌드 옵션 설정
+def generated = 'src/main/generated'
+
+// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile).configureEach {
+    options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+    main.java.srcDirs += [generated]
+}
+
+// gradle clean 시에 QClass 디렉토리 삭제
+clean {
+    delete file(generated)
 }
 
 tasks.named('test') {

--- a/src/main/java/kr/modernworld/modernworldv2/admin/application/api/ItemApi.java
+++ b/src/main/java/kr/modernworld/modernworldv2/admin/application/api/ItemApi.java
@@ -1,0 +1,7 @@
+package kr.modernworld.modernworldv2.admin.application.api;
+
+public interface ItemApi {
+
+  ItemPriceAndTypeDTO getPrice(Long itemNo);
+
+}

--- a/src/main/java/kr/modernworld/modernworldv2/admin/application/api/ItemApiImpl.java
+++ b/src/main/java/kr/modernworld/modernworldv2/admin/application/api/ItemApiImpl.java
@@ -1,0 +1,23 @@
+package kr.modernworld.modernworldv2.admin.application.api;
+
+import kr.modernworld.modernworldv2.admin.domain.port.item.ItemQueryRepository;
+import kr.modernworld.modernworldv2.global.error.BusinessErrorCode;
+import kr.modernworld.modernworldv2.global.error.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ItemApiImpl implements ItemApi {
+
+  private final ItemQueryRepository itemQueryRepository;
+
+  @Override
+  @Transactional(readOnly = true)
+  public ItemPriceAndTypeDTO getPrice(Long itemNo) {
+    return itemQueryRepository.getPriceAndType(itemNo)
+        .orElseThrow(
+            () -> new BusinessException(BusinessErrorCode.NO_SUCH_ITEM, " itemNo: " + itemNo));
+  }
+}

--- a/src/main/java/kr/modernworld/modernworldv2/admin/application/api/ItemPriceAndTypeDTO.java
+++ b/src/main/java/kr/modernworld/modernworldv2/admin/application/api/ItemPriceAndTypeDTO.java
@@ -1,0 +1,10 @@
+package kr.modernworld.modernworldv2.admin.application.api;
+
+import kr.modernworld.modernworldv2.admin.domain.ItemType;
+
+public record ItemPriceAndTypeDTO(
+    Long price,
+    ItemType type
+) {
+
+}

--- a/src/main/java/kr/modernworld/modernworldv2/admin/domain/ItemType.java
+++ b/src/main/java/kr/modernworld/modernworldv2/admin/domain/ItemType.java
@@ -1,0 +1,38 @@
+package kr.modernworld.modernworldv2.admin.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+
+@Getter
+public enum ItemType {
+  ONE("1번 타입"), TWO("2번 타입"), THREE("3번 타입"), FOUR("4번 타입"),
+  FIVE("5번 타입"), SIX("6번 타입"), SEVEN("7번 타입"), EIGHT("8번 타입"),
+  NINE("9번 타입"), TEN("10번 타입"), ELEVEN("11번 타입"), TWELVE("12번 타입");
+
+  private final String str;
+
+  public static ItemType strToItemType(String str) {
+    return itemTypeToStr(str);
+  }
+
+  @JsonCreator
+  public static ItemType itemTypeToStr(String str) {
+    for (ItemType itemType : ItemType.values()) {
+      if (itemType.str.equals(str)) {
+        return itemType;
+
+      }
+    }
+    throw new IllegalArgumentException(str);
+  }
+
+  @JsonValue
+  public String getStr() {
+    return this.str;
+  }
+
+  ItemType(String str) {
+    this.str = str;
+  }
+}

--- a/src/main/java/kr/modernworld/modernworldv2/admin/domain/port/item/ItemQueryRepository.java
+++ b/src/main/java/kr/modernworld/modernworldv2/admin/domain/port/item/ItemQueryRepository.java
@@ -1,0 +1,10 @@
+package kr.modernworld.modernworldv2.admin.domain.port.item;
+
+import java.util.Optional;
+import kr.modernworld.modernworldv2.admin.application.api.ItemPriceAndTypeDTO;
+
+public interface ItemQueryRepository {
+
+  Optional<ItemPriceAndTypeDTO> getPriceAndType(Long itemNo);
+
+}

--- a/src/main/java/kr/modernworld/modernworldv2/admin/domain/port/item/ItemRepository.java
+++ b/src/main/java/kr/modernworld/modernworldv2/admin/domain/port/item/ItemRepository.java
@@ -1,0 +1,5 @@
+package kr.modernworld.modernworldv2.admin.domain.port.item;
+
+public interface ItemRepository {
+
+}

--- a/src/main/java/kr/modernworld/modernworldv2/admin/infrastructure/persistence/entity/BanJPAEntity.java
+++ b/src/main/java/kr/modernworld/modernworldv2/admin/infrastructure/persistence/entity/BanJPAEntity.java
@@ -24,7 +24,7 @@ public class BanJPAEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "no", columnDefinition = "int UNSIGNED not null")
+  @Column(name = "no")
   private Long no;
 
   @Size(max = 300)

--- a/src/main/java/kr/modernworld/modernworldv2/admin/infrastructure/persistence/entity/CharacterJPAEntity.java
+++ b/src/main/java/kr/modernworld/modernworldv2/admin/infrastructure/persistence/entity/CharacterJPAEntity.java
@@ -50,7 +50,7 @@ public class CharacterJPAEntity {
   private String species;
 
   @ColumnDefault("'0'")
-  @Column(name = "price", columnDefinition = "int UNSIGNED not null")
+  @Column(name = "price")
   private Long price;
 
   @OneToMany(mappedBy = "character", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)

--- a/src/main/java/kr/modernworld/modernworldv2/admin/infrastructure/persistence/entity/ItemJPAEntity.java
+++ b/src/main/java/kr/modernworld/modernworldv2/admin/infrastructure/persistence/entity/ItemJPAEntity.java
@@ -13,6 +13,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.ArrayList;
 import java.util.List;
+import kr.modernworld.modernworldv2.admin.domain.ItemType;
 import kr.modernworld.modernworldv2.user.infrastructure.persistence.entity.InventoryJPAEntity;
 import lombok.Getter;
 import lombok.Setter;
@@ -26,7 +27,7 @@ public class ItemJPAEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "no", columnDefinition = "int UNSIGNED not null")
+  @Column(name = "no")
   private Long no;
 
   @Size(max = 15)
@@ -52,10 +53,10 @@ public class ItemJPAEntity {
   @Size(max = 20)
   @NotNull
   @Column(name = "type", nullable = false, length = 20)
-  private String type;
+  private ItemType type;
 
   @ColumnDefault("'0'")
-  @Column(name = "price", columnDefinition = "int UNSIGNED not null")
+  @Column(name = "price")
   private Long price;
 
   @OneToMany(mappedBy = "item", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)

--- a/src/main/java/kr/modernworld/modernworldv2/admin/infrastructure/persistence/entity/ItemTypeConverter.java
+++ b/src/main/java/kr/modernworld/modernworldv2/admin/infrastructure/persistence/entity/ItemTypeConverter.java
@@ -1,0 +1,27 @@
+package kr.modernworld.modernworldv2.admin.infrastructure.persistence.entity;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import kr.modernworld.modernworldv2.admin.domain.ItemType;
+
+@Converter(autoApply = true)
+public class ItemTypeConverter implements AttributeConverter<ItemType, String> {
+
+  @Override
+  public String convertToDatabaseColumn(ItemType entityType) {
+    if (entityType == null) {
+      return null;
+    }
+
+    return entityType.getStr();
+  }
+
+  @Override
+  public ItemType convertToEntityAttribute(String dbData) {
+    if (dbData == null) {
+      return null;
+    }
+
+    return ItemType.strToItemType(dbData);
+  }
+}

--- a/src/main/java/kr/modernworld/modernworldv2/admin/infrastructure/repository/item/ItemQueryRepositoryImpl.java
+++ b/src/main/java/kr/modernworld/modernworldv2/admin/infrastructure/repository/item/ItemQueryRepositoryImpl.java
@@ -1,0 +1,37 @@
+package kr.modernworld.modernworldv2.admin.infrastructure.repository.item;
+
+import static kr.modernworld.modernworldv2.admin.infrastructure.persistence.entity.QItemJPAEntity.itemJPAEntity;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
+import kr.modernworld.modernworldv2.admin.application.api.ItemPriceAndTypeDTO;
+import kr.modernworld.modernworldv2.admin.domain.port.item.ItemQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ItemQueryRepositoryImpl implements ItemQueryRepository {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public Optional<ItemPriceAndTypeDTO> getPriceAndType(Long itemNo) {
+    ItemPriceAndTypeDTO itemInfo = queryFactory
+        .select(
+            Projections.constructor(ItemPriceAndTypeDTO.class,
+                itemJPAEntity.price,
+                itemJPAEntity.type))
+        .from(itemJPAEntity)
+        .where(itemJPAEntity.no.eq(itemNo))
+        .fetchFirst();
+
+    if (itemInfo == null) {
+      return Optional.empty();
+    }
+
+    return Optional.of(itemInfo);
+
+  }
+}

--- a/src/main/java/kr/modernworld/modernworldv2/global/config/QueryDSLConfig.java
+++ b/src/main/java/kr/modernworld/modernworldv2/global/config/QueryDSLConfig.java
@@ -1,0 +1,19 @@
+package kr.modernworld.modernworldv2.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDSLConfig {
+
+  private final EntityManager entityManager;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(entityManager);
+  }
+}

--- a/src/main/java/kr/modernworld/modernworldv2/global/config/security/SecurityConfig.java
+++ b/src/main/java/kr/modernworld/modernworldv2/global/config/security/SecurityConfig.java
@@ -43,6 +43,7 @@ public class SecurityConfig {
         )
 
         .authorizeHttpRequests(authorize -> authorize
+            .requestMatchers("/error").permitAll() // 아무런 에러 핸들링이 안됐을 경우 최후의 보루
             .requestMatchers("/auth/**").permitAll()
             .requestMatchers("/api/admin/**").hasAuthority(UserRole.ROLE_ADMIN.name())
             .anyRequest().authenticated()

--- a/src/main/java/kr/modernworld/modernworldv2/global/error/BusinessErrorCode.java
+++ b/src/main/java/kr/modernworld/modernworldv2/global/error/BusinessErrorCode.java
@@ -1,0 +1,24 @@
+package kr.modernworld.modernworldv2.global.error;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum BusinessErrorCode {
+  NO_SUCH_ITEM(HttpStatus.NOT_FOUND, "There is no item."),
+
+  ITEM_ALREADY_EXISTS_IN_INVENTORY(HttpStatus.CONFLICT, "User already owns the item."),
+  ITEM_TYPE_NOT_FOUND_IN_INVENTORY(HttpStatus.NOT_FOUND, "There is no item type like that."),
+  ITEM_NOT_FOUND_IN_INVENTORY(HttpStatus.NOT_FOUND, "User doesn't have that item."),
+
+  USER_NOT_HAS_ENOUGH_POINT(HttpStatus.FORBIDDEN, "User does not have enough point."),
+  USER_NOT_FOUND(HttpStatus.FORBIDDEN, "User not found.");
+
+  BusinessErrorCode(HttpStatus status, String message) {
+    this.status = status;
+    this.message = message;
+  }
+
+  private final HttpStatus status;
+  private final String message;
+}

--- a/src/main/java/kr/modernworld/modernworldv2/global/error/BusinessException.java
+++ b/src/main/java/kr/modernworld/modernworldv2/global/error/BusinessException.java
@@ -1,0 +1,19 @@
+package kr.modernworld.modernworldv2.global.error;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+  private final BusinessErrorCode errorCode;
+
+  public BusinessException(BusinessErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
+  }
+
+  public BusinessException(BusinessErrorCode errorCode, String plusMessage) {
+    super(errorCode.getMessage() + plusMessage);
+    this.errorCode = errorCode;
+  }
+}

--- a/src/main/java/kr/modernworld/modernworldv2/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/kr/modernworld/modernworldv2/global/error/GlobalExceptionHandler.java
@@ -1,8 +1,10 @@
 package kr.modernworld.modernworldv2.global.error;
 
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -10,6 +12,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+  // Global
   @ExceptionHandler(RuntimeException.class)
   public ResponseEntity<ErrorResponseDTO> handleAllException(RuntimeException ex) {
     log.error(ex.getMessage(), ex);
@@ -21,6 +24,25 @@ public class GlobalExceptionHandler {
     );
 
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+  }
+
+  // Validation Error.
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ErrorResponseDTO> handleValidationFailed(
+      MethodArgumentNotValidException ex) {
+
+    String bindingResults = ex.getBindingResult()
+        .getFieldErrors()
+        .stream()
+        .map(error ->
+            String.format("%s: %s", error.getField(), error.getDefaultMessage()))
+        .collect(Collectors.joining(","));
+
+    ErrorResponseDTO response = new ErrorResponseDTO(bindingResults,
+        HttpStatus.BAD_REQUEST.getReasonPhrase(),
+        HttpStatus.BAD_REQUEST.value());
+
+    return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
   }
 
 }

--- a/src/main/java/kr/modernworld/modernworldv2/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/kr/modernworld/modernworldv2/global/error/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package kr.modernworld.modernworldv2.global.error;
 
+import jakarta.validation.ConstraintViolationException;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -7,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @Slf4j
 @RestControllerAdvice
@@ -19,7 +21,7 @@ public class GlobalExceptionHandler {
 
     ErrorResponseDTO response = new ErrorResponseDTO(
         "Server Error",
-        "INTERNAL_SERVER_ERROR",
+        HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase(),
         HttpStatus.INTERNAL_SERVER_ERROR.value()
     );
 
@@ -45,4 +47,42 @@ public class GlobalExceptionHandler {
     return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
   }
 
+  // validation failed.
+  @ExceptionHandler(ConstraintViolationException.class)
+  public ResponseEntity<ErrorResponseDTO> handleConstraintViolation(
+      ConstraintViolationException ex) {
+
+    String violations = ex.getConstraintViolations().stream().map(violation -> {
+      String path = violation.getPropertyPath().toString();
+      String fieldName = path.substring(path.lastIndexOf('.') + 1);
+
+      return String.format("%s: %s", fieldName, violation.getMessage());
+    }).collect(Collectors.joining(", "));
+
+    ErrorResponseDTO response = new ErrorResponseDTO(
+        violations,
+        HttpStatus.BAD_REQUEST.getReasonPhrase(), HttpStatus.BAD_REQUEST.value());
+
+    return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+  }
+
+  // validation type mismatch.
+  @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+  public ResponseEntity<ErrorResponseDTO> handleMethodArgumentTypeMismatch(
+      MethodArgumentTypeMismatchException ex) {
+    ErrorResponseDTO response = new ErrorResponseDTO(
+        ex.getParameter().getParameterName() + " type is wrong.",
+        HttpStatus.BAD_REQUEST.getReasonPhrase(), HttpStatus.BAD_REQUEST.value());
+
+    return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+  }
+
+  // business exception.
+  @ExceptionHandler(BusinessException.class)
+  public ResponseEntity<ErrorResponseDTO> handleBusinessException(BusinessException ex) {
+    ErrorResponseDTO response = new ErrorResponseDTO(ex.getMessage(),
+        ex.getErrorCode().getMessage(), ex.getErrorCode().getStatus().value());
+
+    return new ResponseEntity<>(response, ex.getErrorCode().getStatus());
+  }
 }

--- a/src/main/java/kr/modernworld/modernworldv2/global/error/UnhandledErrorController.java
+++ b/src/main/java/kr/modernworld/modernworldv2/global/error/UnhandledErrorController.java
@@ -1,0 +1,38 @@
+package kr.modernworld.modernworldv2.global.error;
+
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.web.servlet.error.ErrorController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Slf4j
+public class UnhandledErrorController implements ErrorController {
+
+  // Unhandled Error는 모두 이곳에 모임
+  @RequestMapping("/error")
+  public ResponseEntity<ErrorResponseDTO> error(HttpServletRequest request) {
+
+    // 포워딩 된 Request 에서 Status 추출
+    Object status = request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE);
+    int statusCode = (status != null) ? Integer.parseInt(status.toString()) : 500;
+
+    // 포워딩 된 Request 에서 Exception 추출
+    Throwable exception = (Throwable) request.getAttribute(RequestDispatcher.ERROR_EXCEPTION);
+
+    log.error("Error occurred with status {}: {}", statusCode,
+        (exception != null ? exception.getMessage() : "N/A"), exception);
+
+    ErrorResponseDTO errorResponse = new ErrorResponseDTO(
+        "Unhandled Error occurred.",
+        HttpStatus.valueOf(statusCode).getReasonPhrase(),
+        statusCode
+    );
+
+    return new ResponseEntity<>(errorResponse, HttpStatus.valueOf(statusCode));
+  }
+}

--- a/src/main/java/kr/modernworld/modernworldv2/user/application/InventoryService.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/application/InventoryService.java
@@ -1,0 +1,60 @@
+package kr.modernworld.modernworldv2.user.application;
+
+import java.util.List;
+import kr.modernworld.modernworldv2.admin.domain.ItemType;
+import kr.modernworld.modernworldv2.global.error.BusinessErrorCode;
+import kr.modernworld.modernworldv2.global.error.BusinessException;
+import kr.modernworld.modernworldv2.user.domain.Inventory;
+import kr.modernworld.modernworldv2.user.domain.InventoryCollection;
+import kr.modernworld.modernworldv2.user.domain.port.inventory.InventoryQueryRepository;
+import kr.modernworld.modernworldv2.user.domain.port.inventory.InventoryRepository;
+import kr.modernworld.modernworldv2.user.presentation.inventory.dto.request.GetInventoryRequestDTO;
+import kr.modernworld.modernworldv2.user.presentation.inventory.dto.response.GetInventoryResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class InventoryService {
+
+  private final InventoryRepository inventoryRepository;
+
+  private final InventoryQueryRepository inventoryQueryRepository;
+
+  public List<GetInventoryResponseDTO> getAllItems(Long userNo,
+      GetInventoryRequestDTO query) {
+    return inventoryQueryRepository.getInventory(userNo, query.theme(), query.status(),
+        query.itemName());
+  }
+
+  @Transactional
+  public Inventory addOneItemInInventory(Long userNo, Long itemNo, ItemType itemType) {
+    return inventoryRepository.save(Inventory.create(userNo, itemNo, itemType));
+  }
+
+  @Transactional(readOnly = true)
+  public void validateItemNotExists(Long userNo, Long itemNo) {
+    if (inventoryQueryRepository.isExists(userNo, itemNo)) {
+      throw new BusinessException(BusinessErrorCode.ITEM_ALREADY_EXISTS_IN_INVENTORY);
+    }
+  }
+
+  @Transactional
+  public Inventory updateItemEquipStatus(Long userNo, Long itemNo, Boolean status) {
+    ItemType itemType =
+        inventoryQueryRepository.findInventoryItemType(userNo, itemNo)
+            .orElseThrow(
+                () -> new BusinessException(BusinessErrorCode.ITEM_TYPE_NOT_FOUND_IN_INVENTORY,
+                    " itemNo: " + itemNo));
+
+    InventoryCollection userItems =
+        inventoryQueryRepository.findInventoryByUserNoAndTypeNo(userNo, itemType);
+
+    Inventory response = userItems.equipOrUnequip(itemNo, status);
+
+    inventoryRepository.update(userItems);
+
+    return response;
+  }
+}

--- a/src/main/java/kr/modernworld/modernworldv2/user/application/InventoryService.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/application/InventoryService.java
@@ -35,7 +35,7 @@ public class InventoryService {
 
   @Transactional(readOnly = true)
   public void validateItemNotExists(Long userNo, Long itemNo) {
-    if (inventoryQueryRepository.isExists(userNo, itemNo)) {
+    if (inventoryQueryRepository.exists(userNo, itemNo)) {
       throw new BusinessException(BusinessErrorCode.ITEM_ALREADY_EXISTS_IN_INVENTORY);
     }
   }

--- a/src/main/java/kr/modernworld/modernworldv2/user/application/ItemShopService.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/application/ItemShopService.java
@@ -1,0 +1,44 @@
+package kr.modernworld.modernworldv2.user.application;
+
+import kr.modernworld.modernworldv2.admin.application.api.ItemApi;
+import kr.modernworld.modernworldv2.admin.application.api.ItemPriceAndTypeDTO;
+import kr.modernworld.modernworldv2.global.error.BusinessErrorCode;
+import kr.modernworld.modernworldv2.global.error.BusinessException;
+import kr.modernworld.modernworldv2.user.domain.Inventory;
+import kr.modernworld.modernworldv2.user.domain.port.user.UserQueryRepository;
+import kr.modernworld.modernworldv2.user.domain.port.user.UserRepository;
+import kr.modernworld.modernworldv2.user.domain.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ItemShopService {
+
+  private final ItemApi itemApi;
+  private final UserQueryRepository userQueryRepository;
+  private final InventoryService inventoryService;
+  private final UserRepository userRepository;
+
+  @Transactional
+  public Inventory buyOneItem(Long userNo, Long itemNo) {
+    inventoryService.validateItemNotExists(userNo, itemNo);
+
+    User user = userQueryRepository.findUserCurrentPointByNo(userNo)
+        .orElseThrow(() -> new BusinessException(BusinessErrorCode.USER_NOT_FOUND));
+
+    ItemPriceAndTypeDTO itemInfo = itemApi.getPrice(itemNo);
+
+    try {
+      user.decreaseCurrentPoint(itemInfo.price());
+    } catch (IllegalArgumentException e) {
+      throw new BusinessException(BusinessErrorCode.USER_NOT_HAS_ENOUGH_POINT,
+          " " + e.getMessage());
+    }
+
+    userRepository.updateCurrentPoint(user.getNo(), user.getCurrentPoint());
+    return inventoryService.addOneItemInInventory(userNo, itemNo, itemInfo.type());
+  }
+
+}

--- a/src/main/java/kr/modernworld/modernworldv2/user/application/oauth/OAuthPersistenceService.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/application/oauth/OAuthPersistenceService.java
@@ -1,6 +1,7 @@
 package kr.modernworld.modernworldv2.user.application.oauth;
 
 import kr.modernworld.modernworldv2.user.domain.port.OAuthClient;
+import kr.modernworld.modernworldv2.user.domain.port.user.UserQueryRepository;
 import kr.modernworld.modernworldv2.user.domain.port.user.UserRepository;
 import kr.modernworld.modernworldv2.user.domain.user.User;
 import lombok.RequiredArgsConstructor;
@@ -12,11 +13,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class OAuthPersistenceService {
 
   private final UserRepository userRepository;
+  private final UserQueryRepository userQueryRepository;
 
   @Transactional
   public User toPersistentedUser(SocialUserInfoDTO socialUserInfo, OAuthClient client,
       OAuthTokenDTO socialToken) {
-    User user = userRepository.findByUniqueIdentifier(socialUserInfo.uniqueIdentifier())
+    User user = userQueryRepository.findByUniqueIdentifier(socialUserInfo.uniqueIdentifier())
         .orElseGet(() ->
             User.createFromSocial(
                 socialUserInfo.uniqueIdentifier(),

--- a/src/main/java/kr/modernworld/modernworldv2/user/domain/Inventory.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/domain/Inventory.java
@@ -1,0 +1,47 @@
+package kr.modernworld.modernworldv2.user.domain;
+
+import java.time.Instant;
+import kr.modernworld.modernworldv2.admin.domain.ItemType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class Inventory {
+
+  private final Long no;
+  private final Long userNo;
+  private final Long itemNo;
+  private Boolean status;
+  private final ItemType itemType;
+  private final Instant createdAt;
+
+  @Builder
+  private Inventory(Long no, Long userNo, Long itemNo, Boolean status, ItemType itemType,
+      Instant createdAt) {
+    this.no = no;
+    this.userNo = userNo;
+    this.itemNo = itemNo;
+    this.status = status;
+    this.itemType = itemType;
+    this.createdAt = createdAt;
+  }
+
+  public static Inventory create(Long userNo, Long itemNo, ItemType itemType) {
+    return Inventory.builder()
+        .userNo(userNo)
+        .itemNo(itemNo)
+        .itemType(itemType)
+        .status(false)
+        .createdAt(Instant.now())
+        .build();
+  }
+
+  public void makeStatusTrue() {
+    this.status = true;
+  }
+
+  public void makeStatusFalse() {
+    this.status = false;
+  }
+
+}

--- a/src/main/java/kr/modernworld/modernworldv2/user/domain/InventoryCollection.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/domain/InventoryCollection.java
@@ -1,0 +1,39 @@
+package kr.modernworld.modernworldv2.user.domain;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class InventoryCollection {
+
+  public InventoryCollection(List<Inventory> inventory) {
+    this.inventory = inventory;
+  }
+
+  private final List<Inventory> inventory;
+
+  public Inventory equipOrUnequip(Long itemNo, Boolean status) {
+    Inventory result = null;
+
+    for (Inventory inventory : inventory) {
+      if (inventory.getItemNo().equals(itemNo)) {
+        if (status) {
+          inventory.makeStatusTrue();
+        } else {
+          inventory.makeStatusFalse();
+        }
+
+        result = inventory;
+      } else {
+        inventory.makeStatusFalse();
+      }
+    }
+
+    if (result == null) {
+      throw new IllegalStateException("Inventory does not contain item no: " + itemNo);
+    }
+
+    return result;
+  }
+
+}

--- a/src/main/java/kr/modernworld/modernworldv2/user/domain/port/inventory/InventoryQueryRepository.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/domain/port/inventory/InventoryQueryRepository.java
@@ -1,0 +1,20 @@
+package kr.modernworld.modernworldv2.user.domain.port.inventory;
+
+import java.util.List;
+import java.util.Optional;
+import kr.modernworld.modernworldv2.admin.domain.ItemType;
+import kr.modernworld.modernworldv2.user.domain.InventoryCollection;
+import kr.modernworld.modernworldv2.user.presentation.inventory.dto.response.GetInventoryResponseDTO;
+
+public interface InventoryQueryRepository {
+
+  List<GetInventoryResponseDTO> getInventory(Long userNo,
+      String theme, Boolean status, String itemName);
+
+  Optional<ItemType> findInventoryItemType(Long userNo, Long itemNo);
+
+  InventoryCollection findInventoryByUserNoAndTypeNo(Long userNo, ItemType type);
+
+  Boolean isExists(Long userNo, Long itemNo);
+
+}

--- a/src/main/java/kr/modernworld/modernworldv2/user/domain/port/inventory/InventoryQueryRepository.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/domain/port/inventory/InventoryQueryRepository.java
@@ -15,6 +15,6 @@ public interface InventoryQueryRepository {
 
   InventoryCollection findInventoryByUserNoAndTypeNo(Long userNo, ItemType type);
 
-  Boolean isExists(Long userNo, Long itemNo);
+  Boolean exists(Long userNo, Long itemNo);
 
 }

--- a/src/main/java/kr/modernworld/modernworldv2/user/domain/port/inventory/InventoryRepository.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/domain/port/inventory/InventoryRepository.java
@@ -1,0 +1,11 @@
+package kr.modernworld.modernworldv2.user.domain.port.inventory;
+
+import kr.modernworld.modernworldv2.user.domain.Inventory;
+import kr.modernworld.modernworldv2.user.domain.InventoryCollection;
+
+public interface InventoryRepository {
+
+  Inventory save(Inventory inventory);
+
+  void update(InventoryCollection items);
+}

--- a/src/main/java/kr/modernworld/modernworldv2/user/domain/port/user/UserQueryRepository.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/domain/port/user/UserQueryRepository.java
@@ -1,5 +1,12 @@
 package kr.modernworld.modernworldv2.user.domain.port.user;
 
+import java.util.Optional;
+import kr.modernworld.modernworldv2.user.domain.user.User;
+
 public interface UserQueryRepository {
+
+  Optional<User> findUserCurrentPointByNo(Long userNo);
+
+  Optional<User> findByUniqueIdentifier(String uniqueIdentifier);
 
 }

--- a/src/main/java/kr/modernworld/modernworldv2/user/domain/port/user/UserRepository.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/domain/port/user/UserRepository.java
@@ -1,11 +1,10 @@
 package kr.modernworld.modernworldv2.user.domain.port.user;
 
-import java.util.Optional;
 import kr.modernworld.modernworldv2.user.domain.user.User;
 
 public interface UserRepository {
 
-  Optional<User> findByUniqueIdentifier(String uniqueIdentifier);
+  void updateCurrentPoint(Long userNo, Long newPoint);
 
   User save(User user);
 }

--- a/src/main/java/kr/modernworld/modernworldv2/user/domain/user/User.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/domain/user/User.java
@@ -92,6 +92,15 @@ public class User {
     this.legend = UserLegend.init(no);
   }
 
+  public void decreaseCurrentPoint(Long point) {
+    if (point > this.currentPoint) {
+      throw new IllegalArgumentException("Current point is greater than the input point");
+    }
+
+    this.currentPoint -= point;
+  }
+
+
   public void nullifyDeletedAt() {
     if (this.deletedAt != null) {
       this.deletedAt = null;

--- a/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/mapper/InventoryMapper.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/mapper/InventoryMapper.java
@@ -1,0 +1,21 @@
+package kr.modernworld.modernworldv2.user.infrastructure.mapper;
+
+import kr.modernworld.modernworldv2.global.mapper.TimeMapper;
+import kr.modernworld.modernworldv2.user.domain.Inventory;
+import kr.modernworld.modernworldv2.user.infrastructure.persistence.entity.InventoryJPAEntity;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring", uses = {TimeMapper.class})
+public interface InventoryMapper {
+
+  @Mapping(target = "userNo", source = "user.no")
+  @Mapping(target = "itemType", source = "item.type")
+  @Mapping(target = "itemNo", source = "item.no")
+  Inventory toDomain(InventoryJPAEntity inventoryJPAEntity);
+
+  @Mapping(target = "user.no", source = "userNo")
+  @Mapping(target = "item.no", source = "itemNo")
+  InventoryJPAEntity toJPAEntity(Inventory inventory);
+
+}

--- a/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/persistence/entity/AchievementJPAEntity.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/persistence/entity/AchievementJPAEntity.java
@@ -34,7 +34,7 @@ public class AchievementJPAEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "no", columnDefinition = "int UNSIGNED not null")
+  @Column(name = "no")
   private Long no;
 
   @Size(max = 20)
@@ -57,7 +57,7 @@ public class AchievementJPAEntity {
   @Column(name = "level", nullable = false)
   private AchievementLevel level;
 
-  @Column(name = "point", columnDefinition = "int UNSIGNED not null")
+  @Column(name = "point")
   private Long point;
 
   @Size(max = 10)

--- a/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/persistence/entity/AlarmJPAEntity.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/persistence/entity/AlarmJPAEntity.java
@@ -36,7 +36,7 @@ public class AlarmJPAEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "no", columnDefinition = "int UNSIGNED not null")
+  @Column(name = "no")
   private Long no;
 
   @NotNull

--- a/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/persistence/entity/CharacterLockerJPAEntity.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/persistence/entity/CharacterLockerJPAEntity.java
@@ -40,7 +40,7 @@ public class CharacterLockerJPAEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "no", columnDefinition = "int UNSIGNED not null")
+  @Column(name = "no")
   private Long no;
 
   @NotNull

--- a/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/persistence/entity/CommentJPAEntity.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/persistence/entity/CommentJPAEntity.java
@@ -41,7 +41,7 @@ public class CommentJPAEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "no", columnDefinition = "int UNSIGNED not null")
+  @Column(name = "no")
   private Long no;
 
   @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/persistence/entity/InventoryJPAEntity.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/persistence/entity/InventoryJPAEntity.java
@@ -40,7 +40,7 @@ public class InventoryJPAEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "no", columnDefinition = "int UNSIGNED not null")
+  @Column(name = "no")
   private Long no;
 
   @NotNull

--- a/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/persistence/entity/LegendJPAEntity.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/persistence/entity/LegendJPAEntity.java
@@ -28,7 +28,7 @@ import org.hibernate.annotations.OnDeleteAction;
 public class LegendJPAEntity {
 
   @Id
-  @Column(name = "user_no", columnDefinition = "int UNSIGNED not null")
+  @Column(name = "user_no")
   private Long no;
 
   @MapsId
@@ -38,27 +38,27 @@ public class LegendJPAEntity {
   private UserJPAEntity user;
 
   @ColumnDefault("'0'")
-  @Column(name = "attendance_count", columnDefinition = "int UNSIGNED not null")
+  @Column(name = "attendance_count")
   private Long attendanceCount;
 
   @ColumnDefault("'0'")
-  @Column(name = "item_count", columnDefinition = "int UNSIGNED not null")
+  @Column(name = "item_count")
   private Long itemCount;
 
   @ColumnDefault("'0'")
-  @Column(name = "present_count", columnDefinition = "int UNSIGNED not null")
+  @Column(name = "present_count")
   private Long presentCount;
 
   @ColumnDefault("'0'")
-  @Column(name = "like_count", columnDefinition = "int UNSIGNED not null")
+  @Column(name = "like_count")
   private Long likeCount;
 
   @ColumnDefault("'0'")
-  @Column(name = "comment_count", columnDefinition = "int UNSIGNED not null")
+  @Column(name = "comment_count")
   private Long commentCount;
 
   @ColumnDefault("'0'")
-  @Column(name = "RSP_win_count", columnDefinition = "int UNSIGNED not null")
+  @Column(name = "RSP_win_count")
   private Long rspWinCount;
 
 }

--- a/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/persistence/entity/LikeJPAEntity.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/persistence/entity/LikeJPAEntity.java
@@ -37,7 +37,7 @@ public class LikeJPAEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "no", columnDefinition = "int UNSIGNED not null")
+  @Column(name = "no")
   private Long no;
 
   @NotNull

--- a/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/persistence/entity/NeighborJPAEntity.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/persistence/entity/NeighborJPAEntity.java
@@ -36,7 +36,7 @@ public class NeighborJPAEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "no", columnDefinition = "int UNSIGNED not null")
+  @Column(name = "no")
   private Long no;
 
   @NotNull

--- a/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/persistence/entity/PostJPAEntity.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/persistence/entity/PostJPAEntity.java
@@ -37,7 +37,7 @@ public class PostJPAEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "no", columnDefinition = "int UNSIGNED not null")
+  @Column(name = "no")
   private Long no;
 
   @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/persistence/entity/PresentJPAEntity.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/persistence/entity/PresentJPAEntity.java
@@ -40,7 +40,7 @@ public class PresentJPAEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "no", columnDefinition = "int UNSIGNED not null")
+  @Column(name = "no")
   private Long no;
 
   @NotNull

--- a/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/persistence/entity/ReplyJPAEntity.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/persistence/entity/ReplyJPAEntity.java
@@ -37,7 +37,7 @@ public class ReplyJPAEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "no", columnDefinition = "int UNSIGNED not null")
+  @Column(name = "no")
   private Long no;
 
   @NotNull

--- a/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/persistence/entity/ReportJPAEntity.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/persistence/entity/ReportJPAEntity.java
@@ -39,7 +39,7 @@ public class ReportJPAEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "no", columnDefinition = "int UNSIGNED not null")
+  @Column(name = "no")
   private Long no;
 
   @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/persistence/entity/RspGameRecordJPAEntity.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/persistence/entity/RspGameRecordJPAEntity.java
@@ -38,7 +38,7 @@ public class RspGameRecordJPAEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "no", columnDefinition = "int UNSIGNED not null")
+  @Column(name = "no")
   private Long no;
 
   @NotNull

--- a/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/persistence/entity/TokenJPAEntity.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/persistence/entity/TokenJPAEntity.java
@@ -37,7 +37,7 @@ public class TokenJPAEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "no", columnDefinition = "int UNSIGNED not null")
+  @Column(name = "no")
   private Long no;
 
   @NotNull

--- a/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/persistence/entity/UserAchievementJPAEntity.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/persistence/entity/UserAchievementJPAEntity.java
@@ -40,7 +40,7 @@ public class UserAchievementJPAEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "no", columnDefinition = "int UNSIGNED not null")
+  @Column(name = "no")
   private Long no;
 
   @NotNull

--- a/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/persistence/entity/UserJPAEntity.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/persistence/entity/UserJPAEntity.java
@@ -43,7 +43,7 @@ public class UserJPAEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "no", columnDefinition = "int UNSIGNED not null")
+  @Column(name = "no")
   private Long no;
 
   @Size(max = 10)
@@ -51,11 +51,11 @@ public class UserJPAEntity {
   private String nickname;
 
   @ColumnDefault("'0'")
-  @Column(name = "current_point", columnDefinition = "int UNSIGNED not null")
+  @Column(name = "current_point")
   private Long currentPoint;
 
   @ColumnDefault("'0'")
-  @Column(name = "accumulation_point", columnDefinition = "int UNSIGNED not null")
+  @Column(name = "accumulation_point")
   private Long accumulationPoint;
 
   @Size(max = 150)
@@ -105,7 +105,7 @@ public class UserJPAEntity {
   private UserDomain domain;
 
   @ColumnDefault("'10'")
-  @Column(name = "chance", columnDefinition = "int UNSIGNED not null")
+  @Column(name = "chance")
   private Long chance;
 
   // User의 생명주기와 완전히 동일한 관계

--- a/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/repository/UserQueryRepositoryImpl.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/repository/UserQueryRepositoryImpl.java
@@ -1,0 +1,47 @@
+package kr.modernworld.modernworldv2.user.infrastructure.repository;
+
+import static kr.modernworld.modernworldv2.user.infrastructure.persistence.entity.QUserJPAEntity.userJPAEntity;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
+import kr.modernworld.modernworldv2.user.domain.port.user.UserQueryRepository;
+import kr.modernworld.modernworldv2.user.domain.user.User;
+import kr.modernworld.modernworldv2.user.infrastructure.mapper.UserMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserQueryRepositoryImpl implements UserQueryRepository {
+
+  private final UserJPARepository userJPARepository;
+  private final UserMapper userMapper;
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public Optional<User> findUserCurrentPointByNo(Long userNo) {
+    Long curPoint = queryFactory
+        .select(userJPAEntity.currentPoint)
+        .from(userJPAEntity)
+        .where(userJPAEntity.no.eq(userNo))
+        .fetchOne();
+
+    if (curPoint == null) {
+      return Optional.empty();
+    }
+
+    User user = User.builder()
+        .no(userNo)
+        .currentPoint(curPoint)
+        .build();
+
+    return Optional.of(user);
+  }
+
+  @Override
+  public Optional<User> findByUniqueIdentifier(String uniqueIdentifier) {
+    return userJPARepository.findByUniqueIdentifier(uniqueIdentifier).map(userMapper::toDomain);
+  }
+}

--- a/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/repository/UserRepositoryImpl.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/repository/UserRepositoryImpl.java
@@ -1,28 +1,33 @@
 package kr.modernworld.modernworldv2.user.infrastructure.repository;
 
+import static kr.modernworld.modernworldv2.user.infrastructure.persistence.entity.QUserJPAEntity.userJPAEntity;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityNotFoundException;
-import java.util.Optional;
 import kr.modernworld.modernworldv2.user.domain.port.user.UserRepository;
 import kr.modernworld.modernworldv2.user.domain.user.User;
-import kr.modernworld.modernworldv2.user.infrastructure.mapper.LegendMapper;
-import kr.modernworld.modernworldv2.user.infrastructure.mapper.TokenMapper;
 import kr.modernworld.modernworldv2.user.infrastructure.mapper.UserMapper;
 import kr.modernworld.modernworldv2.user.infrastructure.persistence.entity.UserJPAEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 @RequiredArgsConstructor
+@Transactional
 public class UserRepositoryImpl implements UserRepository {
 
   private final UserJPARepository userJPARepository;
+  private final JPAQueryFactory queryFactory;
   private final UserMapper userMapper;
-  private final TokenMapper tokenMapper;
-  private final LegendMapper legendMapper;
 
   @Override
-  public Optional<User> findByUniqueIdentifier(String uniqueIdentifier) {
-    return userJPARepository.findByUniqueIdentifier(uniqueIdentifier).map(userMapper::toDomain);
+  public void updateCurrentPoint(Long userNo, Long newPoint) {
+    queryFactory
+        .update(userJPAEntity)
+        .set(userJPAEntity.currentPoint, newPoint)
+        .where(userJPAEntity.no.eq(userNo))
+        .execute();
   }
 
   @Override

--- a/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/repository/inventory/InventoryJPARepository.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/repository/inventory/InventoryJPARepository.java
@@ -1,0 +1,10 @@
+package kr.modernworld.modernworldv2.user.infrastructure.repository.inventory;
+
+import kr.modernworld.modernworldv2.user.infrastructure.persistence.entity.InventoryJPAEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface InventoryJPARepository extends JpaRepository<InventoryJPAEntity, Long> {
+
+}

--- a/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/repository/inventory/InventoryQueryRepositoryImpl.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/repository/inventory/InventoryQueryRepositoryImpl.java
@@ -115,7 +115,7 @@ public class InventoryQueryRepositoryImpl implements InventoryQueryRepository {
   }
 
   @Override
-  public Boolean isExists(Long userNo, Long itemNo) {
+  public Boolean exists(Long userNo, Long itemNo) {
     Integer exist = queryFactory
         .selectOne()
         .from(inventoryJPAEntity)

--- a/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/repository/inventory/InventoryQueryRepositoryImpl.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/repository/inventory/InventoryQueryRepositoryImpl.java
@@ -1,0 +1,127 @@
+package kr.modernworld.modernworldv2.user.infrastructure.repository.inventory;
+
+import static kr.modernworld.modernworldv2.admin.infrastructure.persistence.entity.QItemJPAEntity.itemJPAEntity;
+import static kr.modernworld.modernworldv2.user.infrastructure.persistence.entity.QInventoryJPAEntity.inventoryJPAEntity;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.Optional;
+import kr.modernworld.modernworldv2.admin.domain.ItemType;
+import kr.modernworld.modernworldv2.user.domain.Inventory;
+import kr.modernworld.modernworldv2.user.domain.InventoryCollection;
+import kr.modernworld.modernworldv2.user.domain.port.inventory.InventoryQueryRepository;
+import kr.modernworld.modernworldv2.user.infrastructure.mapper.InventoryMapper;
+import kr.modernworld.modernworldv2.user.presentation.inventory.dto.response.GetInventoryResponseDTO;
+import kr.modernworld.modernworldv2.user.presentation.inventory.dto.response.InventoryItemDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class InventoryQueryRepositoryImpl implements InventoryQueryRepository {
+
+  private final JPAQueryFactory queryFactory;
+  private final InventoryMapper inventoryMapper;
+
+  @Override
+  public List<GetInventoryResponseDTO> getInventory(Long userNo, String theme, Boolean status,
+      String itemName) {
+    return queryFactory
+        .select(Projections.constructor(GetInventoryResponseDTO.class,
+            inventoryJPAEntity.no,
+            inventoryJPAEntity.user.no,
+            inventoryJPAEntity.item.no,
+            inventoryJPAEntity.createdAt,
+            inventoryJPAEntity.status,
+            Projections.constructor(InventoryItemDTO.class,
+                itemJPAEntity.no,
+                itemJPAEntity.name,
+                itemJPAEntity.description,
+                itemJPAEntity.image,
+                itemJPAEntity.theme,
+                itemJPAEntity.type,
+                itemJPAEntity.price
+            )
+        ))
+        .from(inventoryJPAEntity)
+        .join(inventoryJPAEntity.item, itemJPAEntity)
+        .where(
+            inventoryJPAEntity.user.no.eq(userNo),
+            itemThemeContains(theme),
+            statusEq(status),
+            itemNameContains(itemName)
+        )
+        .fetch();
+  }
+
+  private BooleanExpression itemThemeContains(String theme) {
+    if (theme == null || theme.isEmpty()) {
+      return null;
+    }
+
+    return inventoryJPAEntity.item.theme.contains(theme);
+  }
+
+  private BooleanExpression itemNameContains(String itemName) {
+    if (itemName == null || itemName.isEmpty()) {
+      return null;
+    }
+
+    return inventoryJPAEntity.item.name.contains(itemName);
+  }
+
+  private BooleanExpression statusEq(Boolean status) {
+    if (status == null) {
+      return null;
+    }
+
+    return inventoryJPAEntity.status.eq(status);
+  }
+
+  @Override
+  public Optional<ItemType> findInventoryItemType(Long userNo, Long itemNo) {
+
+    ItemType s = queryFactory
+        .select(inventoryJPAEntity.item.type)
+        .from(inventoryJPAEntity)
+        .where(inventoryJPAEntity.user.no.eq(userNo), inventoryJPAEntity.item.no.eq(itemNo))
+        .fetchOne();
+
+    if (s == null) {
+      return Optional.empty();
+    }
+
+    return Optional.of(s);
+  }
+
+  @Override
+  public InventoryCollection findInventoryByUserNoAndTypeNo(Long userId, ItemType type) {
+
+    List<Inventory> userItems = queryFactory
+        .selectFrom(inventoryJPAEntity)
+        .where(inventoryJPAEntity.user.no.eq(userId),
+            inventoryJPAEntity.item.type.eq(type))
+        .fetch()
+        .stream()
+        .map(inventoryMapper::toDomain)
+        .toList();
+
+    return new InventoryCollection(userItems);
+  }
+
+  @Override
+  public Boolean isExists(Long userNo, Long itemNo) {
+    Integer exist = queryFactory
+        .selectOne()
+        .from(inventoryJPAEntity)
+        .where(inventoryJPAEntity.user.no.eq(userNo), inventoryJPAEntity.item.no.eq(itemNo))
+        .fetchFirst();
+
+    return exist != null;
+  }
+}

--- a/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/repository/inventory/InventoryRepositoryImpl.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/repository/inventory/InventoryRepositoryImpl.java
@@ -1,0 +1,32 @@
+package kr.modernworld.modernworldv2.user.infrastructure.repository.inventory;
+
+import kr.modernworld.modernworldv2.user.domain.Inventory;
+import kr.modernworld.modernworldv2.user.domain.InventoryCollection;
+import kr.modernworld.modernworldv2.user.domain.port.inventory.InventoryRepository;
+import kr.modernworld.modernworldv2.user.infrastructure.mapper.InventoryMapper;
+import kr.modernworld.modernworldv2.user.infrastructure.persistence.entity.InventoryJPAEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@RequiredArgsConstructor
+@Transactional
+public class InventoryRepositoryImpl implements InventoryRepository {
+
+  private final InventoryJPARepository inventoryJPARepository;
+  private final InventoryMapper inventoryMapper;
+
+  @Override
+  public Inventory save(Inventory inventory) {
+    InventoryJPAEntity save = inventoryJPARepository.save(inventoryMapper.toJPAEntity(inventory));
+
+    return inventoryMapper.toDomain(save);
+  }
+
+  @Override
+  public void update(InventoryCollection items) {
+    inventoryJPARepository.saveAll(
+        items.getInventory().stream().map(inventoryMapper::toJPAEntity).toList());
+  }
+}

--- a/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/repository/jwt/JwtTokenProvider.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/repository/jwt/JwtTokenProvider.java
@@ -56,7 +56,7 @@ public class JwtTokenProvider implements TokenProvider {
     try {
       Claims payload = accessParser.parseSignedClaims(token).getPayload();
 
-      String userNo = payload.getSubject();
+      Long userNo = Long.valueOf(payload.getSubject());
       boolean isAdmin = payload.get("isAdmin", Boolean.class) == Boolean.TRUE;
 
       return new TokenUserInfoDTO(userNo, isAdmin);
@@ -72,7 +72,7 @@ public class JwtTokenProvider implements TokenProvider {
     try {
       Claims payload = refreshParser.parseSignedClaims(token).getPayload();
 
-      String userNo = payload.getSubject();
+      Long userNo = Long.valueOf(payload.getSubject());
       boolean isAdmin = payload.get("isAdmin", Boolean.class) == Boolean.TRUE;
       return new TokenUserInfoDTO(userNo, isAdmin);
     } catch (ExpiredJwtException e) {

--- a/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/repository/jwt/TokenUserInfoDTO.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/infrastructure/repository/jwt/TokenUserInfoDTO.java
@@ -1,7 +1,7 @@
 package kr.modernworld.modernworldv2.user.infrastructure.repository.jwt;
 
 public record TokenUserInfoDTO(
-    String userNo,
+    Long userNo,
     boolean isAdmin
 ) {
 

--- a/src/main/java/kr/modernworld/modernworldv2/user/presentation/inventory/InventoryController.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/presentation/inventory/InventoryController.java
@@ -1,0 +1,72 @@
+package kr.modernworld.modernworldv2.user.presentation.inventory;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import java.util.List;
+import kr.modernworld.modernworldv2.user.application.InventoryService;
+import kr.modernworld.modernworldv2.user.application.ItemShopService;
+import kr.modernworld.modernworldv2.user.domain.Inventory;
+import kr.modernworld.modernworldv2.user.infrastructure.repository.jwt.TokenUserInfoDTO;
+import kr.modernworld.modernworldv2.user.presentation.inventory.dto.request.BuyOneItemRequestDTO;
+import kr.modernworld.modernworldv2.user.presentation.inventory.dto.request.GetInventoryRequestDTO;
+import kr.modernworld.modernworldv2.user.presentation.inventory.dto.request.UpdateInventoryRequestDTO;
+import kr.modernworld.modernworldv2.user.presentation.inventory.dto.response.GetInventoryResponseDTO;
+import kr.modernworld.modernworldv2.user.presentation.inventory.dto.response.InventoryResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Validated
+public class InventoryController {
+
+  private final InventoryService inventoryService;
+  private final ItemShopService itemShopService;
+
+  @GetMapping("/users/{userNo}/items")
+  public ResponseEntity<List<GetInventoryResponseDTO>> getInventory(
+      @PathVariable("userNo") @Min(1) Long userNo,
+      GetInventoryRequestDTO query
+  ) {
+    List<GetInventoryResponseDTO> response = inventoryService.getAllItems(userNo, query);
+
+    return new ResponseEntity<>(response, HttpStatus.OK);
+  }
+
+  @PostMapping("/users/my/items")
+  public ResponseEntity<InventoryResponseDTO> createOneItemInInventory(
+      @AuthenticationPrincipal TokenUserInfoDTO user, @Valid BuyOneItemRequestDTO item
+  ) {
+    Inventory inventory = itemShopService.buyOneItem(user.userNo(), item.itemNo());
+
+    InventoryResponseDTO response = new InventoryResponseDTO(inventory.getNo(),
+        inventory.getUserNo(), inventory.getItemNo(), inventory.getCreatedAt(),
+        inventory.getStatus());
+
+    return new ResponseEntity<>(response, HttpStatus.CREATED);
+  }
+
+  @PatchMapping("/users/my/items/{itemNo}")
+  public ResponseEntity<InventoryResponseDTO> updateOneItemInInventory(
+      @AuthenticationPrincipal TokenUserInfoDTO user,
+      @PathVariable("itemNo") @Min(1) Long itemNo,
+      @Valid UpdateInventoryRequestDTO item
+  ) {
+    Inventory inventory = inventoryService.updateItemEquipStatus(user.userNo(), itemNo,
+        item.status());
+
+    InventoryResponseDTO response = new InventoryResponseDTO(inventory.getNo(),
+        inventory.getUserNo(), inventory.getItemNo(), inventory.getCreatedAt(),
+        inventory.getStatus());
+
+    return new ResponseEntity<>(response, HttpStatus.OK);
+  }
+}

--- a/src/main/java/kr/modernworld/modernworldv2/user/presentation/inventory/dto/request/BuyOneItemRequestDTO.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/presentation/inventory/dto/request/BuyOneItemRequestDTO.java
@@ -1,0 +1,10 @@
+package kr.modernworld.modernworldv2.user.presentation.inventory.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record BuyOneItemRequestDTO(
+    @NotNull @Min(1) Long itemNo
+) {
+
+}

--- a/src/main/java/kr/modernworld/modernworldv2/user/presentation/inventory/dto/request/GetInventoryRequestDTO.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/presentation/inventory/dto/request/GetInventoryRequestDTO.java
@@ -1,0 +1,9 @@
+package kr.modernworld.modernworldv2.user.presentation.inventory.dto.request;
+
+public record GetInventoryRequestDTO(
+    String theme,
+    Boolean status,
+    String itemName
+) {
+
+}

--- a/src/main/java/kr/modernworld/modernworldv2/user/presentation/inventory/dto/request/UpdateInventoryRequestDTO.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/presentation/inventory/dto/request/UpdateInventoryRequestDTO.java
@@ -1,0 +1,11 @@
+package kr.modernworld.modernworldv2.user.presentation.inventory.dto.request;
+
+
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateInventoryRequestDTO(
+    @NotNull(message = "status can be true of false.")
+    Boolean status
+) {
+
+}

--- a/src/main/java/kr/modernworld/modernworldv2/user/presentation/inventory/dto/response/GetInventoryResponseDTO.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/presentation/inventory/dto/response/GetInventoryResponseDTO.java
@@ -1,0 +1,14 @@
+package kr.modernworld.modernworldv2.user.presentation.inventory.dto.response;
+
+import java.time.Instant;
+
+public record GetInventoryResponseDTO(
+    Long no,
+    Long userNo,
+    Long itemNo,
+    Instant createdAt,
+    Boolean status,
+    InventoryItemDTO item
+) {
+
+}

--- a/src/main/java/kr/modernworld/modernworldv2/user/presentation/inventory/dto/response/InventoryItemDTO.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/presentation/inventory/dto/response/InventoryItemDTO.java
@@ -1,0 +1,15 @@
+package kr.modernworld.modernworldv2.user.presentation.inventory.dto.response;
+
+import kr.modernworld.modernworldv2.admin.domain.ItemType;
+
+public record InventoryItemDTO(
+    Long no,
+    String name,
+    String description,
+    String image,
+    String theme,
+    ItemType type,
+    Long price
+) {
+
+}

--- a/src/main/java/kr/modernworld/modernworldv2/user/presentation/inventory/dto/response/InventoryResponseDTO.java
+++ b/src/main/java/kr/modernworld/modernworldv2/user/presentation/inventory/dto/response/InventoryResponseDTO.java
@@ -1,0 +1,13 @@
+package kr.modernworld.modernworldv2.user.presentation.inventory.dto.response;
+
+import java.time.Instant;
+
+public record InventoryResponseDTO(
+    Long no,
+    Long userNo,
+    Long itemNo,
+    Instant createdAt,
+    Boolean status
+) {
+
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -19,12 +19,13 @@ spring:
       supersecretsecretsecretsecretsecretsupersecretsecretsecretsecretsecretsupersecretsecretsecretsecretsecret
     refresh-secret:
       secretsecretsecretsecretsecretsecretsecretsecretsecretsecretsecretsecretsecretsecretsecretsecret
-    access-expiration: 10_800_000 # 3h
+    access-expiration: 2_419_200_000 # 테스트용 30일 짜리 # 10_800_000 # 3h
     refresh-expiration: 604_800_000 # 7d
     issuer: Eomjunsick.com
   jpa:
+    open-in-view: false
     hibernate:
-      ddl-auto: update
+      ddl-auto: update # production 환경에서 update 한번 할것.
     show-sql: true # SQL 쿼리를 표준 출력(console) 에 출력
     properties:
       hibernate:
@@ -64,6 +65,7 @@ server:
 logging:
   level:
     root: info
+    org.springframework.security: debug
     org.hibernate.SQL: debug # 실행된 SQL 문장
     org.hibernate.type.descriptor.sql.BasicBinder: trace # 쿼리의 PreparedStatement에 바인딩되는 실제 값들을 로그로 출력
     org.springframework.web: debug # 요청 처리 흐름 보기


### PR DESCRIPTION
## 🔍 어떤 변경사항인가요?

- [v] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가/수정
- [ ] 기타 (아래에 설명)

---

## 📎 관련 이슈

- 관련 이슈: #14

---

## 📝 변경 내용 요약

- 아이템 추가, 수정(착용, 미착용), 조회 API 생성

---

## 💡 추가 참고 사항 및 알면 좋은 내용 (레퍼런스)

InventoryCollection이 Aggregate Root(AR)을 맡은 역할인데,
하위 엔티티인 Inventory 객체의 생명주기를 온전히 관리하지는 못하고있습니다.

특히 생성 로직에서 Inventory를 마치 AR처럼 활용해서 엄격하게 DDD 원칙을 지켰다고 하기에는 무리가 있는데,
성능상 굳이 InventoryCollection을 통해 관련 생성로직을 이끌어가는 것 보다는, 해당 하위 엔티티인 Inventory 객체 자체를 가지고 로직을 생성하는게 더 이점이 있다고 생각되어 해당 결정을 내렸습니다.

아이템을 장착하거나 장착해제할때에 동일한 type의 item을 가져와서, InventoryCollection 객체의 엔티티로 만든 후 에 아이템을 각각 처리한 후 다시 DB에 저장하는 로직을 취하고 있는데, 성능상 이점은 포기해도(어차피 data가 많지 않아서 괜찮지만) 도메인 객체 중심으로 설계를 하고자하였습니다.