### PR TITLE
Fix/59 bug fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,7 @@ def generated = 'src/main/generated'
 // querydsl QClass 파일 생성 위치를 지정
 tasks.withType(JavaCompile).configureEach {
     options.getGeneratedSourceOutputDirectory().set(file(generated))
+    options.compilerArgs.add("-parameters")
 }
 
 // java source set 에 querydsl QClass 위치 추가

--- a/src/main/java/kr/modernworld/modernworldv2/asset/application/characterlocker/CharacterLockerService.java
+++ b/src/main/java/kr/modernworld/modernworldv2/asset/application/characterlocker/CharacterLockerService.java
@@ -40,6 +40,15 @@ public class CharacterLockerService {
   }
 
   @Transactional
+  public CharacterLocker addCharacterForNewUser(Long userNo, Long characterNo) {
+    if (characterNo >= 1 && characterNo <= 4) {
+      return characterLockerRepository.save(CharacterLocker.create(userNo, characterNo));
+    }
+
+    throw new BusinessException(BusinessErrorCode.NEW_USER_CAN_GET_ONLY_SPECIAL_CHARACTER);
+  }
+
+  @Transactional
   public CharacterLocker equip(Long userNo, Long characterNo) {
     if (!characterLockerQueryRepository.exists(userNo, characterNo)) {
       throw new BusinessException(BusinessErrorCode.CHARACTER_NOT_FOUND_IN_CHARACTER_LOCKER,
@@ -53,6 +62,10 @@ public class CharacterLockerService {
 
     characterLockerRepository.update(userCharacters);
     return equippedCharacterLocker;
+  }
 
+  @Transactional(readOnly = true)
+  public Boolean userHasAnyCharacter(Long userNo) {
+    return characterLockerQueryRepository.userHasAnyCharacter(userNo);
   }
 }

--- a/src/main/java/kr/modernworld/modernworldv2/asset/application/characterlocker/port/CharacterLockerQueryRepository.java
+++ b/src/main/java/kr/modernworld/modernworldv2/asset/application/characterlocker/port/CharacterLockerQueryRepository.java
@@ -13,4 +13,6 @@ public interface CharacterLockerQueryRepository {
   CharacterLockerCollection getUserAllCharacters(Long userNo);
 
   Boolean exists(Long userNo, Long characterNo);
+
+  Boolean userHasAnyCharacter(Long userNo);
 }

--- a/src/main/java/kr/modernworld/modernworldv2/asset/application/shop/CharacterShopService.java
+++ b/src/main/java/kr/modernworld/modernworldv2/asset/application/shop/CharacterShopService.java
@@ -21,6 +21,14 @@ public class CharacterShopService {
 
   @Transactional
   public CharacterLocker buyOneCharacter(Long userNo, Long characterNo) {
+    memberExternalPort.lockUserByUserNo(userNo);
+
+    Boolean exist = characterLockerService.userHasAnyCharacter(userNo);
+
+    if (!exist) {
+      return characterLockerService.addCharacterForNewUser(userNo, characterNo);
+    }
+
     characterLockerService.validateCharacterExists(userNo, characterNo);
 
     Long characterPrice = characterService.getPrice(characterNo);

--- a/src/main/java/kr/modernworld/modernworldv2/asset/domain/external/member/MemberExternalPort.java
+++ b/src/main/java/kr/modernworld/modernworldv2/asset/domain/external/member/MemberExternalPort.java
@@ -2,6 +2,8 @@ package kr.modernworld.modernworldv2.asset.domain.external.member;
 
 public interface MemberExternalPort {
 
+  void lockUserByUserNo(Long userNo);
+
   void validateUser(Long userNo);
 
   void decreaseCurrentPoint(Long userNo, Long amount);

--- a/src/main/java/kr/modernworld/modernworldv2/asset/infrastructure/external/member/AssetMemberExternalAdapter.java
+++ b/src/main/java/kr/modernworld/modernworldv2/asset/infrastructure/external/member/AssetMemberExternalAdapter.java
@@ -12,6 +12,11 @@ public class AssetMemberExternalAdapter implements MemberExternalPort {
   private final UserService userService;
 
   @Override
+  public void lockUserByUserNo(Long userNo) {
+    userService.getUserForUpdate(userNo);
+  }
+
+  @Override
   public void validateUser(Long userNo) {
     userService.isPresent(userNo);
   }

--- a/src/main/java/kr/modernworld/modernworldv2/asset/infrastructure/repository/characterlocker/CharacterLockerQueryRepositoryImpl.java
+++ b/src/main/java/kr/modernworld/modernworldv2/asset/infrastructure/repository/characterlocker/CharacterLockerQueryRepositoryImpl.java
@@ -99,4 +99,15 @@ public class CharacterLockerQueryRepositoryImpl implements CharacterLockerQueryR
 
     return exist != null;
   }
+
+  @Override
+  public Boolean userHasAnyCharacter(Long userNo) {
+    Integer exist = queryFactory
+        .selectOne()
+        .from(characterLockerJPAEntity)
+        .where(characterLockerJPAEntity.user.no.eq(userNo))
+        .fetchFirst();
+
+    return exist != null;
+  }
 }

--- a/src/main/java/kr/modernworld/modernworldv2/asset/presentation/characterlocker/CharacterLockerController.java
+++ b/src/main/java/kr/modernworld/modernworldv2/asset/presentation/characterlocker/CharacterLockerController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -44,7 +45,7 @@ public class CharacterLockerController {
   @PostMapping("/my/characters")
   public ResponseEntity<CharacterLockerResponseDTO> buyOneUserCharacter(
       @AuthenticationPrincipal TokenUserInfoDTO user,
-      CharacterNoRequestDTO characterInfo) {
+      @RequestBody CharacterNoRequestDTO characterInfo) {
     CharacterLocker characterLocker = characterShopService.buyOneCharacter(user.userNo(),
         characterInfo.characterNo());
 

--- a/src/main/java/kr/modernworld/modernworldv2/asset/presentation/inventory/InventoryController.java
+++ b/src/main/java/kr/modernworld/modernworldv2/asset/presentation/inventory/InventoryController.java
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -46,7 +47,7 @@ public class InventoryController {
 
   @PostMapping("/users/my/items")
   public ResponseEntity<InventoryResponseDTO> createOneItemInInventory(
-      @AuthenticationPrincipal TokenUserInfoDTO user, @Valid BuyOneItemRequestDTO item
+      @AuthenticationPrincipal TokenUserInfoDTO user, @Valid @RequestBody BuyOneItemRequestDTO item
   ) {
     Inventory inventory = itemShopService.buyOneItem(user.userNo(), item.itemNo());
 
@@ -60,8 +61,8 @@ public class InventoryController {
   @PatchMapping("/users/my/items/{itemNo}")
   public ResponseEntity<InventoryResponseDTO> updateOneItemInInventory(
       @AuthenticationPrincipal TokenUserInfoDTO user,
-      @PathVariable("itemNo") @Min(1) Long itemNo,
-      @Valid UpdateInventoryRequestDTO item
+      @PathVariable @Min(1) Long itemNo,
+      @Valid @RequestBody UpdateInventoryRequestDTO item
   ) {
     Inventory inventory = inventoryService.updateItemEquipStatus(user.userNo(), itemNo,
         item.status());

--- a/src/main/java/kr/modernworld/modernworldv2/asset/presentation/present/PresentController.java
+++ b/src/main/java/kr/modernworld/modernworldv2/asset/presentation/present/PresentController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -54,7 +55,7 @@ public class PresentController {
   @PatchMapping("/my/presents/{presentNo}")
   public ResponseEntity<PresentResponseDTO> acceptOrReject(
       @AuthenticationPrincipal TokenUserInfoDTO user, @PathVariable Long presentNo,
-      HandlePresentStatus presentStatus) {
+      @RequestBody HandlePresentStatus presentStatus) {
     Present response = presentService.acceptOrReject(user.userNo(), presentNo, presentStatus);
 
     return new ResponseEntity<>(
@@ -75,7 +76,7 @@ public class PresentController {
   public ResponseEntity<PresentResponseDTO> giveOnePresent(
       @AuthenticationPrincipal TokenUserInfoDTO user,
       @PathVariable("userNo") Long receiverNo,
-      @Valid ItemNoRequestDTO item
+      @Valid @RequestBody ItemNoRequestDTO item
   ) {
     Present response = presentService.createOnePresent(user.userNo(), receiverNo, item.itemNo());
 

--- a/src/main/java/kr/modernworld/modernworldv2/global/error/BusinessErrorCode.java
+++ b/src/main/java/kr/modernworld/modernworldv2/global/error/BusinessErrorCode.java
@@ -51,6 +51,8 @@ public enum BusinessErrorCode {
   CHARACTER_ALREADY_EXISTS(HttpStatus.CONFLICT, "User already owns the character."),
   CHARACTER_NOT_FOUND_IN_CHARACTER_LOCKER(HttpStatus.NOT_FOUND,
       "User does not have that character."),
+  NEW_USER_CAN_GET_ONLY_SPECIAL_CHARACTER(HttpStatus.FORBIDDEN,
+      "only new user can get special character"),
 
   ITEM_ALREADY_EXISTS_IN_INVENTORY(HttpStatus.CONFLICT, "User already owns the item."),
   ITEM_TYPE_NOT_FOUND_IN_INVENTORY(HttpStatus.NOT_FOUND, "There is no item type like that."),

--- a/src/main/java/kr/modernworld/modernworldv2/growth/application/legend/dto/LegendDTO.java
+++ b/src/main/java/kr/modernworld/modernworldv2/growth/application/legend/dto/LegendDTO.java
@@ -6,7 +6,8 @@ public record LegendDTO(
     Long commentCount,
     Long itemCount,
     Long presentCount,
-    Long likeCount
+    Long likeCount,
+    Long rspWinCount
 ) {
 
 }

--- a/src/main/java/kr/modernworld/modernworldv2/growth/infrastructure/repository/legend/LegendQueryRepositoryImpl.java
+++ b/src/main/java/kr/modernworld/modernworldv2/growth/infrastructure/repository/legend/LegendQueryRepositoryImpl.java
@@ -43,7 +43,8 @@ public class LegendQueryRepositoryImpl implements LegendQueryRepository {
             legendJPAEntity.commentCount,
             legendJPAEntity.itemCount,
             legendJPAEntity.presentCount,
-            legendJPAEntity.likeCount
+            legendJPAEntity.likeCount,
+            legendJPAEntity.rspWinCount
         ))
         .from(legendJPAEntity)
         .where(legendJPAEntity.no.eq(userNo))

--- a/src/main/java/kr/modernworld/modernworldv2/growth/presentation/legend/dto/res/LegendResponseDTO.java
+++ b/src/main/java/kr/modernworld/modernworldv2/growth/presentation/legend/dto/res/LegendResponseDTO.java
@@ -8,7 +8,8 @@ public record LegendResponseDTO(
     Long commentCount,
     Long itemCount,
     Long presentCount,
-    Long likeCount
+    Long likeCount,
+    Long rspWinCount
 ) {
 
   public static LegendResponseDTO from(LegendDTO dto) {
@@ -18,7 +19,8 @@ public record LegendResponseDTO(
         dto.commentCount(),
         dto.itemCount(),
         dto.presentCount(),
-        dto.likeCount()
+        dto.likeCount(),
+        dto.rspWinCount()
     );
   }
 }

--- a/src/main/java/kr/modernworld/modernworldv2/growth/presentation/userachievement/UserAchievementController.java
+++ b/src/main/java/kr/modernworld/modernworldv2/growth/presentation/userachievement/UserAchievementController.java
@@ -15,6 +15,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -43,7 +44,7 @@ public class UserAchievementController {
   public ResponseEntity<UserAchievement> updateAchievement(
       @AuthenticationPrincipal TokenUserInfoDTO user,
       @PathVariable Long achievementNo,
-      UpdateUserAchievementStatusDTO body) {
+      @RequestBody UpdateUserAchievementStatusDTO body) {
 
     UserAchievement response = userAchievementService.updateUserAchievementStatus(
         user.userNo(), achievementNo, body.status());

--- a/src/main/java/kr/modernworld/modernworldv2/member/application/auth/OAuthService.java
+++ b/src/main/java/kr/modernworld/modernworldv2/member/application/auth/OAuthService.java
@@ -11,11 +11,11 @@ import kr.modernworld.modernworldv2.member.application.user.UserService;
 import kr.modernworld.modernworldv2.member.domain.auth.port.OAuthClient;
 import kr.modernworld.modernworldv2.member.domain.auth.port.SessionRepository;
 import kr.modernworld.modernworldv2.member.domain.auth.port.TokenProvider;
+import kr.modernworld.modernworldv2.member.domain.token.RefreshTokenRepository;
 import kr.modernworld.modernworldv2.member.domain.user.User;
 import kr.modernworld.modernworldv2.member.domain.user.UserDomain;
 import kr.modernworld.modernworldv2.member.infrastructure.auth.jwt.TokenResultDTO;
 import kr.modernworld.modernworldv2.member.infrastructure.auth.jwt.TokenUserInfoDTO;
-import kr.modernworld.modernworldv2.member.domain.token.RefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -78,8 +78,10 @@ public class OAuthService {
 
     eventPublisher.publishEvent(new LoginSuccessEvent(this));
 
-    return new LoginResultDTO(accessToken.token(), refreshToken.token(),
-        savedUser.getSocialName(),
+    return new LoginResultDTO(
+        accessToken.token(),
+        refreshToken.token(),
+        savedUser.getNickname(),
         savedUser.getNo(),
         accessToken.expirationMillis(),
         refreshToken.expirationMillis());

--- a/src/main/java/kr/modernworld/modernworldv2/member/application/user/UserService.java
+++ b/src/main/java/kr/modernworld/modernworldv2/member/application/user/UserService.java
@@ -190,4 +190,11 @@ public class UserService {
 
     return new UserDescriptionDTO(userNo, description);
   }
+
+  @Transactional
+  public User getUserForUpdate(Long userNo) {
+    return userRepository.findUserByUserNoForUpdate(userNo).orElseThrow(
+        () -> new BusinessException(BusinessErrorCode.USER_NOT_FOUND, " userNo: " + userNo));
+
+  }
 }

--- a/src/main/java/kr/modernworld/modernworldv2/member/presentation/user/UserController.java
+++ b/src/main/java/kr/modernworld/modernworldv2/member/presentation/user/UserController.java
@@ -27,6 +27,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -70,7 +71,8 @@ public class UserController {
 
   @PostMapping("/my/nickname")
   public ResponseEntity<UserNicknameResponseDTO> createUserNickname(
-      @AuthenticationPrincipal TokenUserInfoDTO user, @Valid CreateUserNicknameRequestDTO body) {
+      @AuthenticationPrincipal TokenUserInfoDTO user,
+      @Valid @RequestBody CreateUserNicknameRequestDTO body) {
     UserNicknameDTO response = userService.createUserNickname(user.userNo(), body.nickname());
 
     return new ResponseEntity<>(UserNicknameResponseDTO.from(response), HttpStatus.CREATED);
@@ -79,7 +81,7 @@ public class UserController {
   @PatchMapping("/my/attendance")
   public ResponseEntity<UserAttendanceResponseDTO> updateAttendance(
       @AuthenticationPrincipal TokenUserInfoDTO user,
-      @Valid UpdateUserAttendanceRequestDTO body) {
+      @Valid @RequestBody UpdateUserAttendanceRequestDTO body) {
     UserAttendanceDTO response = userService.updateAttendance(user.userNo(),
         body.stickerNo());
 
@@ -89,7 +91,7 @@ public class UserController {
   @PutMapping("/my/description")
   public ResponseEntity<UserDescriptionResponseDTO> updateDescription(
       @AuthenticationPrincipal TokenUserInfoDTO user,
-      @Valid UpdateUserDescriptionRequestDTO body) {
+      @Valid @RequestBody UpdateUserDescriptionRequestDTO body) {
     UserDescriptionDTO response = userService.updateDescription(user.userNo(),
         body.description());
 

--- a/src/main/java/kr/modernworld/modernworldv2/notification/application/sse/SseEmitterService.java
+++ b/src/main/java/kr/modernworld/modernworldv2/notification/application/sse/SseEmitterService.java
@@ -17,12 +17,14 @@ public class SseEmitterService {
   private static final Long SSE_TTL = 30 * 60 * 1000L;
 
   public SseEmitter connect(Long userNo) {
-    String emitterName = userNo.toString() + "_" + System.currentTimeMillis();
+    sseEmitterRepository.deleteAll(String.valueOf(userNo));
+
+    String emitterName = userNo + "_" + System.currentTimeMillis();
     SseEmitter emitter = new SseEmitter(SSE_TTL);
 
-    emitter.onCompletion(() -> sseEmitterRepository.deleteAll(String.valueOf(userNo)));
-    emitter.onTimeout(() -> sseEmitterRepository.deleteAll(String.valueOf(userNo)));
-    emitter.onError((e) -> sseEmitterRepository.deleteAll(String.valueOf(userNo)));
+    emitter.onCompletion(() -> sseEmitterRepository.deleteById(emitterName));
+    emitter.onTimeout(() -> sseEmitterRepository.deleteById(emitterName));
+    emitter.onError((e) -> sseEmitterRepository.deleteById(emitterName));
 
     sseEmitterRepository.create(emitterName, emitter);
 
@@ -38,7 +40,6 @@ public class SseEmitterService {
     for (SseEmitter emitter : emitters.values()) {
       sendEvent(userNo, emitter, event);
     }
-
   }
 
   private void sendEvent(Long userNo, SseEmitter emitter, Object event) {
@@ -48,9 +49,8 @@ public class SseEmitterService {
           .name("message")
           .data(event));
     } catch (IOException e) {
-      log.error("SSE connection Error: {}", e.getMessage());
-      sseEmitterRepository.deleteAll(String.valueOf(userNo));
-      throw new RuntimeException(e);
+      log.error("UserNo: {}, SSE connection Error: {}", userNo, e.getMessage());
+      emitter.completeWithError(e);
     }
   }
 

--- a/src/main/java/kr/modernworld/modernworldv2/notification/application/sse/port/SseEmitterRepository.java
+++ b/src/main/java/kr/modernworld/modernworldv2/notification/application/sse/port/SseEmitterRepository.java
@@ -11,4 +11,6 @@ public interface SseEmitterRepository {
 
   void deleteAll(String userNo);
 
+  void deleteById(String id);
+
 }

--- a/src/main/java/kr/modernworld/modernworldv2/notification/infrastructure/sse/SseEmitterRepositoryImpl.java
+++ b/src/main/java/kr/modernworld/modernworldv2/notification/infrastructure/sse/SseEmitterRepositoryImpl.java
@@ -39,4 +39,9 @@ public class SseEmitterRepositoryImpl implements SseEmitterRepository {
       }
     }
   }
+
+  @Override
+  public void deleteById(String id) {
+    emitters.remove(id);
+  }
 }

--- a/src/main/java/kr/modernworld/modernworldv2/social/presentation/comment/CommentController.java
+++ b/src/main/java/kr/modernworld/modernworldv2/social/presentation/comment/CommentController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -38,7 +39,7 @@ public class CommentController {
   @PostMapping("/users/{userNo}/comments")
   public ResponseEntity<CommentResponseDTO> create(
       @AuthenticationPrincipal TokenUserInfoDTO user, @PathVariable("userNo") Long receiverNo,
-      @Valid CreateCommentRequestDTO body) {
+      @Valid @RequestBody CreateCommentRequestDTO body) {
     CommentDTO response = commentService.create(user.userNo(), receiverNo,
         body.content());
 
@@ -62,7 +63,7 @@ public class CommentController {
   @PatchMapping("/users/my/comments/{commentNo}")
   public ResponseEntity<CommentResponseDTO> updateOne(
       @AuthenticationPrincipal TokenUserInfoDTO user,
-      @PathVariable Long commentNo, @Valid CreateCommentRequestDTO body) {
+      @PathVariable Long commentNo, @Valid @RequestBody CreateCommentRequestDTO body) {
     CommentDTO response = commentService.update(user.userNo(), commentNo,
         body.content());
 

--- a/src/main/java/kr/modernworld/modernworldv2/social/presentation/post/PostController.java
+++ b/src/main/java/kr/modernworld/modernworldv2/social/presentation/post/PostController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -49,7 +50,7 @@ public class PostController {
 
   @PostMapping("/{userNo}/posts")
   public ResponseEntity<PostResponseDTO> create(@AuthenticationPrincipal TokenUserInfoDTO user,
-      @PathVariable("userNo") Long receiverNo, @Valid CreateOnePostRequestDTO body) {
+      @PathVariable("userNo") Long receiverNo, @Valid @RequestBody CreateOnePostRequestDTO body) {
     PostDTO response = postService.create(user.userNo(), receiverNo, body.content());
 
     return new ResponseEntity<>(PostResponseDTO.from(response), HttpStatus.CREATED);

--- a/src/main/java/kr/modernworld/modernworldv2/social/presentation/reply/ReplyController.java
+++ b/src/main/java/kr/modernworld/modernworldv2/social/presentation/reply/ReplyController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -47,7 +48,7 @@ public class ReplyController {
   @PostMapping("/comments/{commentNo}/replies")
   public ResponseEntity<CreateReplyResponseDTO> create(
       @AuthenticationPrincipal TokenUserInfoDTO user,
-      @PathVariable Long commentNo, @Valid CreateReplyRequestDTO body) {
+      @PathVariable Long commentNo, @Valid @RequestBody CreateReplyRequestDTO body) {
     String response = replyService.create(user.userNo(), commentNo, body.content());
 
     return new ResponseEntity<>(new CreateReplyResponseDTO(response), HttpStatus.CREATED);
@@ -57,7 +58,7 @@ public class ReplyController {
   public ResponseEntity<CreateReplyResponseDTO> updateOne(
       @AuthenticationPrincipal TokenUserInfoDTO user,
       @PathVariable Long commentNo, @PathVariable Long replyNo,
-      @Valid CreateReplyRequestDTO body) {
+      @Valid @RequestBody CreateReplyRequestDTO body) {
     String response = replyService.update(user.userNo(), replyNo, body.content());
 
     return new ResponseEntity<>(new CreateReplyResponseDTO(response), HttpStatus.OK);

--- a/src/main/java/kr/modernworld/modernworldv2/social/presentation/rsp/RSPController.java
+++ b/src/main/java/kr/modernworld/modernworldv2/social/presentation/rsp/RSPController.java
@@ -15,6 +15,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -38,7 +39,7 @@ public class RSPController {
   @PostMapping("/my/rock-scissors-paper")
   public ResponseEntity<RSPResponseDTO> create(
       @AuthenticationPrincipal TokenUserInfoDTO user,
-      @Valid RSPRequestDTO body) {
+      @Valid @RequestBody RSPRequestDTO body) {
     GetRSPDTO response = rspService.create(user.userNo(), body.choice());
 
     return new ResponseEntity<>(RSPResponseDTO.from(response), HttpStatus.CREATED);


### PR DESCRIPTION
## 📌 PR 제목 형식

<!-- 예시: feat: 사용자 로그인 기능 구현 -->

---

## 🔍 어떤 변경사항인가요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 기능 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가/수정
- [ ] 기타 (아래에 설명)

---

## 📎 관련 이슈

- 관련 이슈: #59 

---

## 📝 변경 내용 요약

user 로그인시, nickname이 존재하지 않으면 null혹은""를 보내줘야함.

user가 character를 보유하지 않고 있을 시, 1~4번 캐릭터는 공짜로 보유할 수 있어야 함.

user 업적 현황 조회시, 가위바위보 승리 횟수 안담아서 보내는 버그

sse 커넥션 관련 객체가 메모리상에 기하급수적으로 쌓이는 버그

